### PR TITLE
seeding combined-4.8 ran, pao examples 4.8

### DIFF
--- a/base/configs/pao/01-pao-ran-du-dell03-profile0.yaml
+++ b/base/configs/pao/01-pao-ran-du-dell03-profile0.yaml
@@ -1,0 +1,29 @@
+# Dell EMC PowerEdge XR12
+# 1x Intel Ice Lake 6338R
+---
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: ran-du-dell03-profile0
+spec:
+  cpu:
+    isolated: "4-31,36-63"
+    reserved: "0-3,32-35"
+  net:
+    userLevelNetworking: true
+    devices:
+    - interfaceName: "eno8*"
+    - interfaceName: "ens3*"
+    - interfaceName: "ens4*"
+  hugepages:
+    defaultHugepagesSize: "1G"
+    pages:
+    - size: "1G"
+      count: 16
+      node: 0
+  numa:
+    topologyPolicy: best-effort
+  realTimeKernel:
+    enabled: true
+  nodeSelector:
+    node-role.kubernetes.io/ran-du-dell03: ""

--- a/base/configs/pao/01-pao-ran-du-smci00-profile0.yaml
+++ b/base/configs/pao/01-pao-ran-du-smci00-profile0.yaml
@@ -1,0 +1,28 @@
+# SuperMicro SSC515-R407, MBD-X11SPW-TF-O Motherboard
+# 1x Intel Cascade Lake 6212U
+---
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: ran-du-smci00-profile0
+spec:
+  cpu:
+    isolated: "3-23,27-47"
+    reserved: "0-2,24-26"
+  net:
+    userLevelNetworking: true
+    devices:
+    - interfaceName: "eno*"
+    - interfaceName: "ens2f*"
+  hugepages:
+    defaultHugepagesSize: "1G"
+    pages:
+    - size: "1G"
+      count: 16
+      node: 0
+  numa:
+    topologyPolicy: best-effort
+  realTimeKernel:
+    enabled: true
+  nodeSelector:
+    node-role.kubernetes.io/ran-du-smci00: ""

--- a/base/configs/pao/01-pao-ran-du-smci01-profile0.yaml
+++ b/base/configs/pao/01-pao-ran-du-smci01-profile0.yaml
@@ -1,0 +1,28 @@
+# SuperMicro SYS-210P, MBD-X12SPM-LN6TF Motherboard
+# Supermicro with 1x Intel Ice Lake 6338R
+---
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: ran-du-smci01-profile0
+spec:
+  cpu:
+    isolated: "4-31,36-63"
+    reserved: "0-3,32-35"
+  net:
+    userLevelNetworking: true
+    devices:
+    - interfaceName: "eno*"
+    - interfaceName: "eth*"
+  hugepages:
+    defaultHugepagesSize: "1G"
+    pages:
+    - size: "1G"
+      count: 16
+      node: 0
+  numa:
+    topologyPolicy: best-effort
+  realTimeKernel:
+    enabled: true
+  nodeSelector:
+    node-role.kubernetes.io/ran-du-smci01: ""

--- a/base/operators/README.md
+++ b/base/operators/README.md
@@ -1,3 +1,3 @@
 # ABOUT
 
-This folder contains OLM operators used by 5GC and RAN clusters. These are referenced by the clusters GitOps dir definitions.
+This folder contains OLM operators used by 5GC and RAN clusters. These are referenced by the clusters GitOps directory definitions.

--- a/base/operators/openshift-sriov-network-operator/kustomization.yaml
+++ b/base/operators/openshift-sriov-network-operator/kustomization.yaml
@@ -3,4 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 bases:
-  - sriov-4.7
+  - sriov-4.8

--- a/base/operators/openshift-sriov-network-operator/sriov-4.8/kustomization.yaml
+++ b/base/operators/openshift-sriov-network-operator/sriov-4.8/kustomization.yaml
@@ -5,8 +5,5 @@ kind: Kustomization
 bases:
   - ../common
 
-resources:
-  - 03-unsupported-nic-ids.yaml
-
 patches:
   - patch.yaml

--- a/blueprints/combined-ran-4.8/01-max-pods-500.yaml
+++ b/blueprints/combined-ran-4.8/01-max-pods-500.yaml
@@ -1,0 +1,20 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: max-pods-500 
+spec:
+  machineConfigPoolSelector:
+    matchLabels:
+      custom-kubelet: max-pods-500 
+  kubeletConfig:
+    # unlimited Pods per core
+    podsPerCore: 0
+    # max Pods per Node (max must be less than node CIDR)
+    # For /23, the max IP available are 2^(32-23)-2 = 510
+    maxPods: 500 
+
+
+# oc label machineconfigpool master custom-kubelet=max-pods-500
+# oc label machineconfigpool worker custom-kubelet=max-pods-500
+# oc label machineconfigpool ran-du custom-kubelet=max-pods-500
+# oc label machineconfigpool ran-cu custom-kubelet=max-pods-500

--- a/blueprints/combined-ran-4.8/01-mcp.yaml
+++ b/blueprints/combined-ran-4.8/01-mcp.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: master
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: worker

--- a/blueprints/combined-ran-4.8/01-patch-mcp-master.yaml
+++ b/blueprints/combined-ran-4.8/01-patch-mcp-master.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata: 
+  labels:
+    custom-kubelet: max-pods-500
+    machineconfiguration.openshift.io/role: master
+  name: master
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata: 
+  labels:
+    custom-kubelet: max-pods-500
+    machineconfiguration.openshift.io/role: worker
+  name: worker
+
+# oc label machineconfigpool master custom-kubelet=max-pods-500 machineconfiguration.openshift.io/role=master

--- a/blueprints/combined-ran-4.8/02-mcp-ran-cu.yaml
+++ b/blueprints/combined-ran-4.8/02-mcp-ran-cu.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata: 
+  labels:
+    custom-kubelet: max-pods-500
+    machineconfiguration.openshift.io/role: ran-cu
+  name: ran-cu
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - {
+          key: machineconfiguration.openshift.io/role,
+          operator: In,
+          values: [worker, ran, ran-cu]
+        }
+  paused: false
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/ran-cu: ""

--- a/blueprints/combined-ran-4.8/02-mcp-ran-du.yaml
+++ b/blueprints/combined-ran-4.8/02-mcp-ran-du.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata: 
+  labels:
+    custom-kubelet: max-pods-500
+    machineconfiguration.openshift.io/role: ran-du
+  name: ran-du
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - {
+          key: machineconfiguration.openshift.io/role,
+          operator: In,
+          values: [worker, ran, ran-du]
+        }
+  paused: false
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/ran-du: ""

--- a/blueprints/combined-ran-4.8/03-patch-sriov-operator.yaml
+++ b/blueprints/combined-ran-4.8/03-patch-sriov-operator.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: sriov-network-operator-subscription
+spec:
+  channel: "4.8"

--- a/blueprints/combined-ran-4.8/50-ran-du-disable-chronyd.yaml
+++ b/blueprints/combined-ran-4.8/50-ran-du-disable-chronyd.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: ran-du
+  name: 50-ran-du-disable-chronyd
+spec:
+  config:
+    ignition:
+      version: 3.1.0
+    systemd:
+      units:
+      - contents: |
+          [Unit]
+          Description=NTP client/server
+          Documentation=man:chronyd(8) man:chrony.conf(5)
+          After=ntpdate.service sntp.service ntpd.service
+          Conflicts=ntpd.service systemd-timesyncd.service
+          ConditionCapability=CAP_SYS_TIME
+          [Service]
+          Type=forking
+          PIDFile=/run/chrony/chronyd.pid
+          EnvironmentFile=-/etc/sysconfig/chronyd
+          ExecStart=/usr/sbin/chronyd $OPTIONS
+          ExecStartPost=/usr/libexec/chrony-helper update-daemon
+          PrivateTmp=yes
+          ProtectHome=yes
+          ProtectSystem=full
+          [Install]
+          WantedBy=multi-user.target
+        enabled: false
+        name: chronyd.service

--- a/blueprints/combined-ran-4.8/kustomization.yaml
+++ b/blueprints/combined-ran-4.8/kustomization.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  telco-gitops/combined-ran-4.6: telco-gitops
+
+bases:
+  # RWN
+  - ../rwn
+  # Enable SCTP
+  - ../../base/configs/sctp
+  # SRIOV
+  - ../../base/operators/openshift-sriov-network-operator
+  # PAO
+  - ../../base/operators/openshift-performance-addon-operator/pao-4.8
+  # PTP
+  - ../../base/operators/openshift-ptp/ptp-4.8
+  # Intel vRAN Acceleration Operators
+  - ../../base/operators/vran-acceleration-operators
+
+resources:
+  - 01-max-pods-500.yaml
+  - 02-mcp-ran-cu.yaml
+  - 02-mcp-ran-du.yaml
+  - 50-ran-du-disable-chronyd.yaml
+  # TODO: replace by ks8 job
+  - 01-mcp.yaml
+
+patches:
+# TODO: replace by k8s job
+- 01-patch-mcp-master.yaml
+- 03-patch-sriov-operator.yaml


### PR DESCRIPTION
seed contents for 4.8 combined ran approach
remove override for Intel E810 cards not needed in 4.8
example pao manifests for reference only in configs/ directory
