### PR TITLE
restore assisted installer operator image

### DIFF
--- a/base/operators/assisted-installer/01-install.yaml
+++ b/base/operators/assisted-installer/01-install.yaml
@@ -7,6 +7,15 @@ metadata:
     name: assisted-installer
     openshift.io/cluster-monitoring: "true"
 ---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: assisted-service
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: quay.io/ocpmetal/assisted-service-index:latest
+---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -22,8 +31,8 @@ metadata:
   name: assisted-service-operator
   namespace: assisted-installer
 spec:
-  channel: ocm-2.3
+  channel: alpha
   installPlanApproval: Automatic
   name: assisted-service-operator
-  source: community-operators
+  source: assisted-service
   sourceNamespace: openshift-marketplace


### PR DESCRIPTION
adjust OpenShift Infrastructure Operator to pull from quay temporarily
community operator in marketplace (0.0.7) is buggy and non functioning