### PR TITLE
Adding a new exclusion for ManagedClusterInfo

### DIFF
--- a/base/configs/telco-gitops/05-argocd-telco-gitops.yaml
+++ b/base/configs/telco-gitops/05-argocd-telco-gitops.yaml
@@ -84,6 +84,12 @@ spec:
       kinds:
       - TaskRun
       - PipelineRun
+    - apiGroups:
+      - internal.open-cluster-management.io
+      clusters:
+      - '*'
+      kinds:
+      - ManagedClusterInfo
   server:
     autoscale:
       enabled: false


### PR DESCRIPTION
Adding a new exclusion to telco-gitops ArgoCD instance. This will remove the out of sync issue with this Kind of object that is shown in Argo since the object is created by RHACM and it is not synced from our repo.

Signed-off-by: Alberto Losada <alosadag@redhat.com>