### PR TITLE
Adding a blueprint when using RHACM's assisted service

### DIFF
--- a/blueprints/mgmt-rhacm/kustomization.yaml
+++ b/blueprints/mgmt-rhacm/kustomization.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  telco-gitops/mgmt: telco-gitops
+
+bases:
+  #####################################################
+  # Operators for MGMT Clusters
+  #####################################################
+  # Common Telco Optimizations
+  - ../../base/configs/telco-optimized
+  # OpenShift GitOps
+  - ../../base/operators/openshift-gitops
+  # OpenShift Pipelines
+  - ../../base/operators/openshift-pipelines
+  # OpenShift Serverless
+  ##- ../../base/operators/openshift-serverless
+  # # Assisted Installer (now Infrastructre Operator)
+  ##- ../../base/operators/assisted-installer
+  # Red Hat Advanced Cluster Manager for Kubernetes
+  - ../../base/operators/advanced-cluster-management
+  # OpenShift Container storage
+  # - ../../base/operators/openshift-container-storage
+  # Quay Enterprise
+  # - ../../base/operators/quay-enterprise-operator
+  # OpenShift Logging
+  # - ../../base/operators/openshift-logging


### PR DESCRIPTION
Starting to work on a blueprint that leverages RHACM's Assisted service instead of installing a new one. Currently, we have validated the one that is included in v2.3.1 of RHACM and we have been able to provision several clusters.

Basically, we have removed the call to the Infrastructure Operator and included RHACM installation.

Signed-off-by: Alberto Losada <alosadag@redhat.com>