### PR TITLE
Adding nmstate to the list of operators

### DIFF
--- a/base/operators/openshift-nmstate/kustomization.yaml
+++ b/base/operators/openshift-nmstate/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - nmstate-4.8

--- a/base/operators/openshift-nmstate/nmstate-4.8/01-nmstate-namespace.yaml
+++ b/base/operators/openshift-nmstate/nmstate-4.8/01-nmstate-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-nmstate

--- a/base/operators/openshift-nmstate/nmstate-4.8/02-nmstate-operatorgroup.yaml
+++ b/base/operators/openshift-nmstate/nmstate-4.8/02-nmstate-operatorgroup.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-nmstate-operator
+  namespace: openshift-nmstate
+spec:
+  targetNamespaces:
+  - openshift-nmstate

--- a/base/operators/openshift-nmstate/nmstate-4.8/03-nmstate-subscription.yaml
+++ b/base/operators/openshift-nmstate/nmstate-4.8/03-nmstate-subscription.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-nmstate-operator-subscription
+  namespace: openshift-nmstate 
+spec:
+  channel: "4.8" 
+  name: kubernetes-nmstate-operator
+  source: redhat-operators 
+  sourceNamespace: openshift-marketplace

--- a/base/operators/openshift-nmstate/nmstate-4.8/04-nmstate-instance.yaml
+++ b/base/operators/openshift-nmstate/nmstate-4.8/04-nmstate-instance.yaml
@@ -1,0 +1,10 @@
+apiVersion: nmstate.io/v1beta1
+kind: NMState
+metadata:
+  name: nmstate
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+spec:
+  nodeSelector:
+    beta.kubernetes.io/arch: amd64

--- a/base/operators/openshift-nmstate/nmstate-4.8/kustomization.yaml
+++ b/base/operators/openshift-nmstate/nmstate-4.8/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - 01-nmstate-namespace.yaml
+  - 02-nmstate-operatorgroup.yaml
+  - 03-nmstate-subscription.yaml
+  - 04-nmstate-instance.yaml


### PR DESCRIPTION
We use NMstate operator for day 2 operations when configuring all-network-related things on the cluster. Would like to include it in the list of base operators

Signed-off-by: Alberto Losada <alosadag@redhat.com>